### PR TITLE
Add UCPC 2025 registration link

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,6 +4,7 @@ title: 전국 대학생 프로그래밍 대회 동아리 연합
 ---
 
 <!-- ## [UCPC 2024 신청하기](https://2024.ucpc.me){:target="_blank"} -->
+## [UCPC 2025 신청하기](https://2025.ucpc.me){:target="_blank"}
 
 ## 공지
 - (2025-04-21) UCPC 2025가 개최될 예정입니다 -- 대회 페이지: [링크](https://2025.ucpc.me){:target="_blank"}


### PR DESCRIPTION
## Summary
- add 2025 UCPC registration link to index

## Testing
- `bundle exec jekyll build` *(fails: version `2.6.8` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847d1432658833083d129a90fc13f4f