### PR TITLE
chore: 운영진 정보 최신화

### DIFF
--- a/index.md
+++ b/index.md
@@ -81,14 +81,14 @@ title: 전국 대학생 프로그래밍 대회 동아리 연합
 | 직책 | 이름 (BOJ 핸들) | 소속 |
 | :---: | :--- | --- |
 | 회장 | 신민철 ([@fefe](https://www.acmicpc.net/user/fefe){:target="_blank"}) | KAIST |
-| 운영진 | 강호현 ([@annieho](https://www.acmicpc.net/user/annieho){:target="_blank"}) | 연세대학교 |
+| 부회장 | 강호현 ([@annieho](https://www.acmicpc.net/user/annieho){:target="_blank"}) | 연세대학교 |
+| 부회장 | 이예린 ([@abra_stone](https://www.acmicpc.net/user/abra_stone){:target="_blank"}) | KAIST |
+| 부회장 | 장근영 ([@azberjibiou](https://www.acmicpc.net/user/azberjibiou){:target="_blank"}) | KAIST |
 | 운영진 | 이성현 ([@hibye1217](https://www.acmicpc.net/user/hibye1217){:target="_blank"}) | 한양대학교 |
-| 운영진 | 이예린 ([@abra_stone](https://www.acmicpc.net/user/abra_stone){:target="_blank"}) | KAIST |
 | 운영진 | 이종서 ([@leejseo](https://www.acmicpc.net/user/leejseo){:target="_blank"}) | KAIST |
 | 운영진 | 이종학 ([@js9028](https://www.acmicpc.net/user/js9028){:target="_blank"}) | 아주대학교 |
 | 운영진 | 이준휘 ([@johnny8337](https://www.acmicpc.net/user/johnny8337){:target="_blank"}) | KAIST |
 | 운영진 | 오유림 ([@clp135](https://www.acmicpc.net/user/clp135){:target="_blank"}) | 연세대학교 |
-| 운영진 | 장근영 ([@azberjibiou](https://www.acmicpc.net/user/azberjibiou){:target="_blank"}) | KAIST |
 | 운영진 | 정은채 ([@celina324](https://www.acmicpc.net/user/celina324){:target="_blank"}) | 이화여자대학교 |
 | 운영진 | 정우경 ([@man_of_learning](https://www.acmicpc.net/user/man_of_learning){:target="_blank"}) | 전북대학교 |
 


### PR DESCRIPTION
## 📌 요약
- 운영진 정보를 최신화합니다.

## 🔍 변경사항
- 이하람님을 운영진 리스트에서 제거합니다.
- 강호현님, 이예린님, 장근영님의 직책을 부회장으로 수정합니다.

## 🧠 변경이유
- 이하람님이 개인사정으로 전대프연 임원진을 그만두셨습니다.
- 운영진 1 on 1 이후 각 운영진의 직책을 확정했습니다.

## 🖼️ 스크린샷 / 데모 (Screenshots / Demo)
<img width="808" height="643" alt="Screenshot 2026-02-21 at 09 07 47" src="https://github.com/user-attachments/assets/551194db-7223-47e0-a32d-e2f0147fda77" />


## 🧪 How to Test
로컬 테스트.

## 📝 TODO
읎음

## ⚠️ 참고사항

## 🔗 관련 이슈
없음.