### PR TITLE
feat: 메인 페이지에 ucpc 2026 페이지 링크 추가

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -10,6 +10,7 @@ permalink: /en/
 <!-- ## [2025 전대프연 세미나 신청하기](https://seminar.ucpc.me/){:target="_blank"} -->
 
 ## Notices
+- (2026-02-26) **UCPC 2026 is coming** — Contest page: [Link](https://2026.ucpc.me){:target="_blank"}
 - (2025-04-21) **UCPC 2025 is coming** — Contest page: [Link](https://2025.ucpc.me){:target="_blank"}
 - (2025-03-07) **UCPC 2025 — Call for Tasks is now open** [Link](https://2025.ucpc.me/tasks/){:target="_blank"}.
 - (2024-03-25) **UCPC 2024 — Call for Tasks is now open** [Link](https://2024.ucpc.me/tasks/){:target="_blank"}.

--- a/index.md
+++ b/index.md
@@ -9,6 +9,7 @@ lang: ko
 <!-- ## [2025 전대프연 세미나 신청하기](https://seminar.ucpc.me/){:target="_blank"} -->
 
 ## 공지
+- (2026-02-26) UCPC 2026가 개최될 예정입니다 -- 대회 페이지: [링크](https://2026.ucpc.me){:target="_blank"}
 - (2025-04-21) UCPC 2025가 개최될 예정입니다 -- 대회 페이지: [링크](https://2025.ucpc.me){:target="_blank"}
 - (2025-03-07) UCPC 2025의 [Call for Tasks](https://2025.ucpc.me/tasks/){:target="_blank"}를 진행합니다.
 - (2024-03-25) UCPC 2024의 [Call for tasks](https://2024.ucpc.me/tasks/){:target="_blank"}를 진행합니다.


### PR DESCRIPTION
## 📌 요약
- ucpc.me에 2026.ucpc.me로 가는 링크를 추가했습니다.

## 🔍 변경사항
- "UCPC 2026가 개최될 예정입니다" 문구와 2026년 대회 페이지 링크를 추가했습니다.

## 🧠 변경이유
- 참가자들에게 ucpc 2026 열린다는 사실 알리기 위함입니다.

## 🖼️ 스크린샷 / 데모 (Screenshots / Demo)


## 🧪 How to Test
로컬 테스트.

## 📝 TODO
- 2026.ucpc.me 영문 번역 이후 ucpc.me/en은 2026.ucpc.me/en으로 가도록 설정.

## ⚠️ 참고사항
없음

## 🔗 관련 이슈
없음.