### PR TITLE
feat: add UCPC 2026 registration notice

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -5,12 +5,15 @@ lang: en
 permalink: /en/
 ---
 
+## [Register for UCPC 2026](https://forms.gle/g5ByqXEgFSw7QR2d7){:target="_blank"}
+
 <!-- ## [UCPC 2024 신청하기](https://2024.ucpc.me){:target="_blank"} -->
 <!-- ## [UCPC 2025 신청하기](https://2025.ucpc.me){:target="_blank"} -->
 <!-- ## [2025 전대프연 세미나 신청하기](https://seminar.ucpc.me/){:target="_blank"} -->
 
 ## Notices
 
+- (2026-06-05) **Registration for UCPC 2026 is open.** Registration closes on June 18, 2026. Please submit through the [registration form](https://forms.gle/g5ByqXEgFSw7QR2d7){:target="_blank"}.
 - (2026-03-11) **UCPC 2026 — Call for Tasks is now open** [Link](https://2026.ucpc.me/tasks/){:target="\_blank"}.
 - (2026-02-26) **UCPC 2026 is coming** — Contest page: [Link](https://2026.ucpc.me){:target="\_blank"}
 - (2025-04-21) **UCPC 2025 is coming** — Contest page: [Link](https://2025.ucpc.me){:target="\_blank"}

--- a/index.md
+++ b/index.md
@@ -4,12 +4,15 @@ title: 전국 대학생 프로그래밍 대회 동아리 연합
 lang: ko
 ---
 
+## [UCPC 2026 참가 신청하기](https://forms.gle/g5ByqXEgFSw7QR2d7){:target="_blank"}
+
 <!-- ## [UCPC 2024 신청하기](https://2024.ucpc.me){:target="_blank"} -->
 <!-- ## [UCPC 2025 신청하기](https://2025.ucpc.me){:target="_blank"} -->
 <!-- ## [2025 전대프연 세미나 신청하기](https://seminar.ucpc.me/){:target="_blank"} -->
 
 ## 공지
 
+- (2026-06-05) UCPC 2026의 참가 신청을 받고 있습니다. 참가 신청은 2026년 6월 18일까지이며, [참가 신청](https://forms.gle/g5ByqXEgFSw7QR2d7){:target="_blank"}을 참고해주세요.
 - (2026-03-11) UCPC 2026의 [Call for Tasks](https://2026.ucpc.me/tasks/){:target="\_blank"}를 진행합니다.
 - (2026-02-26) UCPC 2026가 개최될 예정입니다 -- 대회 페이지: [링크](https://2026.ucpc.me){:target="\_blank"}
 - (2025-04-21) UCPC 2025가 개최될 예정입니다 -- 대회 페이지: [링크](https://2025.ucpc.me){:target="\_blank"}


### PR DESCRIPTION
## Summary
- add UCPC 2026 registration CTA to Korean and English home pages
- add registration notice with deadline: June 18, 2026
- link registration form: https://forms.gle/g5ByqXEgFSw7QR2d7

## Testing
- `docker compose -f docker-compose.local.yml run --rm site bundle exec jekyll build`
- verified Korean and English local HTML responses include the registration link and deadline